### PR TITLE
ci: add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v6
+      
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+          
+      - name: Restore dependencies
+        run: dotnet restore
+        
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+        
+      - name: Test
+        run: dotnet test --no-build --no-restore --configuration Release --verbosity normal


### PR DESCRIPTION
## Summary
Adds GitHub Actions CI workflow for automated build and test on push/PR.

## Changes
- New `.github/workflows/ci.yml` with standard .NET CI pipeline
- Triggers on push to main and PRs to main
- Uses .NET 9.0.x (matching current `TargetFramework`)
- Steps: restore → build → test

## Approval
Requested by Philippe via Garry (INBOX 2026-02-22 08:11 UTC)

Standard .NET CI setup for Mediateur (MediatR alternative).